### PR TITLE
Refactor: rename functions, cap response, add comments: endpoint, curl, docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ tail -n 20 -f ~/Library/Logs/Claude/mcp-server-maestro-mcp.log
 - /assets/runes/:id
 - /addresses/:id/runes
 - /addresses/:id/utxos
-- /addresses/:id/runes/:id
 - /addresses/:id/txs
 
 All Maestro API specifications can be found in our Postman [workspace](https://www.postman.com/go-maestro/maestro-api/overview).

--- a/maestro.py
+++ b/maestro.py
@@ -76,6 +76,12 @@ async def blockchain_info() -> Dict:
     Retrieve blockchain info
 
     Endpoint: /rpc/general/info
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/rpc/general/info' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/t2mux52/bitcoin-node-rpc-api?entity=request-fe1a486d-53a3-44c0-b7a3-0bc233b00eab
     '''
     return await fetch_api('rpc/general/info')
 
@@ -86,6 +92,12 @@ async def latest_block() -> Dict:
     Retrieve latest block
 
     Endpoint: /rpc/block/latest
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/rpc/block/latest?page=1&count=100&verbose=%3Cboolean%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/t2mux52/bitcoin-node-rpc-api?entity=request-83060ed5-343c-45c2-b54e-197a037aab74
     '''
     params = {'page': 1, 'count': 100}
     return await fetch_api('rpc/block/latest', params=params)
@@ -97,6 +109,14 @@ async def send_transaction(raw_tx: str) -> Dict:
     Submit a raw Bitcoin transaction
 
     Endpoint: /rpc/transaction/submit
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/rpc/transaction/submit' \
+--header 'Content-Type: application/json' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}' \
+--data '{{raw_tx}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/t2mux52/bitcoin-node-rpc-api?entity=request-e183fa71-d233-465d-8fb5-9dca19c6fa8f
     '''
     data = {'tx': raw_tx}
     return await post_api('rpc/transaction/submit', data)
@@ -106,7 +126,13 @@ async def transaction_info_rpc(tx_id: str) -> Dict:
     '''
     Retrieve raw transaction details from RPC endpoint
 
-    Endpoint: /rpc/transaction/:tx_id 
+    Endpoint: /rpc/transaction/:tx_id
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/rpc/transaction/{{tx_id}}?verbose=%3Cboolean%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/t2mux52/bitcoin-node-rpc-api?entity=request-0c8f904a-5046-4306-894a-6718d435dea6
     '''
     return await fetch_api(f'rpc/transaction/{tx_id}')
 
@@ -134,6 +160,12 @@ async def transactions_by_address(address_id: str) -> List[Dict]:
     Retrieve all transactions for a Bitcoin address (paginated)
 
     Endpoint: /addresses/:address_id/txs 
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/addresses/{{address_id}}/txs?count=100&confirmations=%3Clong%3E&order=asc&from=%3Clong%3E&to=%3Clong%3E&cursor=%3Cstring%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-d3a65d0d-d000-42fa-a4d3-da33c87fdb4b
     '''
 
     async def fetch_page(cursor: Optional[str]) -> Dict:
@@ -161,7 +193,13 @@ async def runes_by_address(address_id: str) -> Dict:
     '''
     Map of all Runes tokens and corresponding amounts in UTxOs controlled by the specified address or script pubkey (paginated)
 
-    Endpoint: /addresses/:address_id/runes 
+    Endpoint: /addresses/:address_id/runes
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/addresses/{{address_id}}/runes' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-9e576b6f-1ad1-4d96-b735-b4c5db199ffc
     '''
 
     async def fetch_page(cursor: Optional[str]) -> Dict:
@@ -189,7 +227,13 @@ async def utxos_by_address(address_id: str) -> List[Dict]:
     '''
     List of all UTxOs which reside at the specified address or script pubkey (paginated)
 
-    Endpoint: /addresses/:address_id/utxos 
+    Endpoint: /addresses/:address_id/utxos
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/addresses/{{address_id}}/utxos?filter_dust=%3Cboolean%3E&filter_dust_threshold=%3Clong%3E&exclude_metaprotocols=%3Cboolean%3E&count=100&order=asc&from=%3Clong%3E&to=%3Clong%3E&cursor=%3Cstring%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-2e419a52-351c-4900-8899-6076b9fddcb7
     '''
 
     async def fetch_page(cursor: Optional[str]) -> Dict:
@@ -204,6 +248,12 @@ async def runes_info(rune_id: str) -> Dict:
     Retrieve rune metadata by rune ID
 
     Endpoint: /assets/:rune_id
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/assets/runes/{{rune_id}}' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-f88bd246-c75f-4b64-87f2-7b92c4890c48
     '''
     return await fetch_api(f'assets/runes/{rune_id}')
 
@@ -212,17 +262,29 @@ async def list_runes() -> Dict:
     '''
     List of ID and names of all deployed Rune assets
 
-    Endpoint: /assets/runes 
+    Endpoint: /assets/runes
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/assets/runes?count=100&cursor=%3Cstring%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-f868e716-6b9f-4774-9d53-40c01e159851
     '''
     return await fetch_api('assets/runes')
 
 ## Transactions
 @mcp.tool()
-async def fetch_transaction_details(tx_id: str) -> Dict:
+async def transaction_info_indexer(tx_id: str) -> Dict:
     '''
     Retrieve transaction metadata
 
-    Endpoint: /transactions/:tx_id 
+    Endpoint: /transactions/:tx_id
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/transactions/{{tx_id}}' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/3lhc5bu/bitcoin-blockchain-indexer-api?entity=request-30817523-22bd-4c1d-baf7-3e6963936a42
     '''
     return await fetch_api(f'transactions/{tx_id}')
 
@@ -249,7 +311,13 @@ async def utxos_by_address_mempool_aware(address_id: str) -> List[Dict]:
     '''
     List of all UTxOs which reside at the specified address or script pubkey (mempool-aware, paginated)
 
-    Endpoint: /mempool/addresses/:address_id/utxos 
+    Endpoint: /mempool/addresses/:address_id/utxos
+
+    CURL: curl --location 'https://xbt-mainnet.gomaestro-api.org/v0/mempool/addresses/{{address_id}}/utxos?filter_dust=%3Cboolean%3E&filter_dust_threshold=%3Clong%3E&exclude_metaprotocols=%3Cboolean%3E&count=100&order=asc&from=%3Clong%3E&to=%3Clong%3E&mempool_blocks_limit=%3Cinteger%3E&cursor=%3Cstring%3E' \
+--header 'Accept: application/json' \
+--header 'api-key: {{apiKey}}'
+
+    Docs URL: https://www.postman.com/go-maestro/maestro-api/documentation/p2pmda6/bitcoin-mempool-monitoring-api?entity=request-f0188244-aed4-497c-b845-2fbda382adac
     '''
 
     async def fetch_page(cursor: Optional[str]) -> Dict:

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,6 @@ dependencies = [
     { name = "dotenv" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
-    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -136,7 +135,6 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
-    { name = "setuptools", specifier = ">=78.1.0" },
 ]
 
 [[package]]
@@ -266,15 +264,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
-]
-
-[[package]]
-name = "setuptools"
-version = "78.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR renames the functions to be more similar to the endpoint names so that there is less confusion. It also caps the number of items to return to **5** (hardcoded value). It also adds comments within each function block detailing the:
- [x] endpoint
- [x] curl request
- [x] corresponding docs link

Closes: #8 